### PR TITLE
Configure API doc tool, add docstrings

### DIFF
--- a/backend/recruitmentapp/apps/api/urls.py
+++ b/backend/recruitmentapp/apps/api/urls.py
@@ -2,5 +2,5 @@ from django.urls import path, include
 
 
 urlpatterns = [
-    path('v1/', include('recruitmentapp.apps.api.v1.urls'))
+    path('v1/', include('recruitmentapp.apps.api.v1.urls')),
 ]

--- a/backend/recruitmentapp/apps/api/v1/permissions.py
+++ b/backend/recruitmentapp/apps/api/v1/permissions.py
@@ -1,8 +1,9 @@
 from rest_framework.permissions import BasePermission
 
 
-class IsRecruiter(BasePermission):
-    """The user is a recruiter."""
+class IsRecruiterOrStaff(BasePermission):
+    """The user is a recruiter or staff member."""
 
     def has_permission(self, request, view):
-        return request.user.is_authenticated and request.user.is_recruiter
+        return request.user.is_authenticated \
+               and (request.user.is_recruiter or request.user.is_staff)

--- a/backend/recruitmentapp/apps/api/v1/serializers.py
+++ b/backend/recruitmentapp/apps/api/v1/serializers.py
@@ -4,6 +4,11 @@ from recruitmentapp.apps.core.models import User, Applicant
 
 
 class ApplicantSerializer(serializers.Serializer):
+    """Combines fields from a User and an associated Applicant.
+
+    Should be given an Applicant when instantiated.
+    """
+
     username = serializers.CharField(
         source='user.username',
         max_length=150
@@ -25,6 +30,9 @@ class ApplicantSerializer(serializers.Serializer):
     social_security_number = serializers.CharField(max_length=20)
 
     def create(self, validated_data):
+        """Create a new applicant from validated data."""
+
+        # TODO: Add error handling for if create_user() fails.
         user = User.objects.create_user(
             username=validated_data["username"],
             password=validated_data["password"],

--- a/backend/recruitmentapp/apps/api/v1/urls.py
+++ b/backend/recruitmentapp/apps/api/v1/urls.py
@@ -1,9 +1,26 @@
+from django.conf.urls import url
 from django.urls import path
-from rest_framework import routers
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import routers, permissions
 from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token, \
     verify_jwt_token
 
 from recruitmentapp.apps.api.v1.views import ApplicantViewSet
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Recruitment API",
+      default_version='v1',
+      description="",
+      terms_of_service="",
+      contact=openapi.Contact(email=""),
+      license=openapi.License(name=""),
+   ),
+   validators=[],
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
 
 router = routers.SimpleRouter()
 router.register(r'applicants', ApplicantViewSet)
@@ -12,6 +29,20 @@ urlpatterns = [
     path('login/', obtain_jwt_token),
     path('login-refresh', refresh_jwt_token),
     path('login-verify/', verify_jwt_token),
+    url(
+        r'^swagger(?P<format>.json|.yaml)$',
+        schema_view.without_ui(cache_timeout=None),
+        name='schema-json',
+    ),
+    url(
+        r'^swagger/$',
+        schema_view.with_ui('swagger', cache_timeout=None),
+        name='schema-swagger-ui',
+    ),
+    url(r'^redoc/$',
+        schema_view.with_ui('redoc', cache_timeout=None),
+        name='schema-redoc',
+    ),
 ]
 
 urlpatterns += router.urls

--- a/backend/recruitmentapp/apps/api/v1/views.py
+++ b/backend/recruitmentapp/apps/api/v1/views.py
@@ -3,25 +3,40 @@ from rest_framework.generics import get_object_or_404
 
 from rest_framework.response import Response
 
-from recruitmentapp.apps.api.v1.permissions import IsRecruiter
+from recruitmentapp.apps.api.v1.permissions import IsRecruiterOrStaff
 from recruitmentapp.apps.api.v1.serializers import ApplicantSerializer
 from recruitmentapp.apps.core.models import Applicant
 
 
 class ApplicantViewSet(viewsets.GenericViewSet):
-    """Viewset for recruiters to access Applicants."""
+    """Viewset for recruiters to manage applicants/applications, and for
+    applicants to manage their own data.
+    """
 
     queryset = Applicant.objects.all()
     serializer_class = ApplicantSerializer
-    permission_classes = (IsRecruiter,)
+    permission_classes = (IsRecruiterOrStaff,)
 
     def retrieve(self, request, pk=None):
+        """Retrieve a single applicant.
+
+        ### Permissions
+        User must be a recruiter or staff member.
+        TODO: Enable applicants to retrieve their own data.
+        """
+
         applicant = get_object_or_404(self.get_queryset(), pk=pk)
         serializer = self.get_serializer_class()
         serializer(applicant)
         return Response(serializer.data)
 
     def list(self, request):
+        """List all applicants.
+
+        ### Permissions
+        User must be a recruiter or staff member.
+        """
+
         applicants = self.get_queryset()
         serializer = self.get_serializer_class()(applicants, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/backend/recruitmentapp/apps/core/models.py
+++ b/backend/recruitmentapp/apps/core/models.py
@@ -2,8 +2,9 @@ from django.contrib.auth.models import AbstractUser
 from django.db import models
 
 
-# Create your models here.
 class User(AbstractUser):
+    """Used for authentication of all users."""
+
     def __str__(self):
         return self.username
 
@@ -13,6 +14,8 @@ class User(AbstractUser):
 
 
 class Applicant(models.Model):
+    """A person who is applying for a job."""
+
     user = models.OneToOneField(
         User,
         on_delete=models.CASCADE,
@@ -25,6 +28,8 @@ class Applicant(models.Model):
 
 
 class Recruiter(models.Model):
+    """A person who is recruiting from among the applicants."""
+
     user = models.OneToOneField(
         User,
         on_delete=models.CASCADE,

--- a/backend/recruitmentapp/settings.py
+++ b/backend/recruitmentapp/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'recruitmentapp.apps.core',
     'rest_framework',
     'corsheaders',
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
- Configure API doc tool [drf-yasg](https://github.com/axnsan12/drf-yasg/). Presents API documentation at `/api/v1/swagger/` or `/api/v1/redoc/` (two alternative UIs).
- Add docstrings.
- Tweak recruiter permission class.